### PR TITLE
Denoising Autoencoders

### DIFF
--- a/delft/delft.py
+++ b/delft/delft.py
@@ -78,6 +78,29 @@ class Autoencoder(object):
     def __init__(self, compression_factor,
                  encoder_activation, decoder_activation,
                  optimizer, activity_regularizer, dropout_rate, nb_epoch=50):
+        """
+        Initializes one layer of an artificial neural network
+
+        Parameters
+        ----------
+        compression_factor: float
+            The number of neurons in this layer is determined by dividing the number of neurons in the previous
+            layer by the compression factor. A compression factor greater than 0 and less than 1 causes an expansion.
+        encoder_activation: Activation
+            The activation function of this layer
+        decoder_activation: Activation
+            The activation function of the decoding layer that corresponds to this encoding layer in a
+            stacked autoencoder architecture. Used in pre-training a neural network.
+        optimizer: Optimizer
+            The optimization method to control the gradient steps of the algorithm.
+            Only the optimizer in the first layer is used.
+        activity_regularizer: Activity_Regularizer
+            The activity regularizer to help the algorithm find simpler models and generalize better.
+        dropout_rate: 0 <= float <= 1
+            Percentage of the input values of this layer that will be set to zero.
+        nb_epoch: int (Default: 50)
+            Number of epochs for pre-training and training this layer.
+        """
 
         self.compression_factor = compression_factor
         self.encoder_activation = encoder_activation
@@ -87,52 +110,44 @@ class Autoencoder(object):
         self.activity_regularizer = activity_regularizer
         self.dropout_rate = dropout_rate
 
-    def set_model(self, model):
-        self.model = model
-
-    def set_dataframe(self, input_df):
-        self.dataframe = input_df
-
-    def get_dataframe(self):
-        return self.dataframe
-
-    def get_code(self, input_df):
+    def start_encoder(self, train_df, validate_df, excess_columns):
         """
-        Generates a code (encoding) from the input.
-        A model must first have been trained.
+        Creates the first hidden layer in a stacked autoencoder or neural network, and connects it to the input
+        layer. This method also instantiates the Input class from Keras, and must be called before calling
+        the `stack_encoder` method of this class.
 
         Parameters
         ----------
-        :input_df: pandas DataFrame
+        train_df: pandas.DataFrame
+            training set.
+        validate_df: pandas.DataFrame
+            validation set.
+        excess_columns: int
+            The number of columns added to train_df and validate_df by TPOT that are not features of the data.
+            For example, "guess", "class", and "group" are non-feature columns in train_df and validate_df,
+            so excess_columns is 3. This value is calculated by len(non_feature_columns) when this method is called.
 
         Returns
-        ----------
-        numpy 2darray
+        -------
+        None
 
         """
-        #maximo = ceil(input_df.max().max())
-        #input_df = input_df / maximo
-        return self.encoder.predict(input_df.values)
-
-    def get_reconstruction(self, input_df):
-        return self.model.predict(input_df.values)
-
-    def start_encoder(self, train_df, validate_df, excess_columns):
         try:
             self.train_df = train_df
             self.validate_df = validate_df
             nbr_columns = train_df.shape[1] - excess_columns
             self.nbr_columns = nbr_columns
-            nbr_drop_columns = int(nbr_columns*self.dropout_rate)
+            _input = Input(shape=(nbr_columns,))
+            self.input = _input
 
             if self.compression_factor == 0:
                 # Behavior undefined. Do not change feature space.
                 self.compression_factor = 1
 
+            # encoding_dim is the number of columns in this layer, nbr_columns is the number of columns in the previous
+            # layer.
             encoding_dim = ceil(nbr_columns / self.compression_factor)
             self.encoding_dim = encoding_dim
-            _input = Input(shape=(nbr_columns,))
-            self.input = _input
 
             code_layer = Dense(encoding_dim, activation=self.encoder_activation,
                                activity_regularizer=self.activity_regularizer)(_input)
@@ -142,17 +157,37 @@ class Autoencoder(object):
             print(e)
 
     def stack_encoder(self, nbr_columns, code_layer, _input):
+        """
+        Creates any hidden layer, except the first hidden layer, in a stacked autoencoder or neural network,
+        and connects the previous layer to this layer.
+        For creating the first layer, see Autoencoder.start_encoder.
+
+        Parameters
+        ----------
+        nbr_columns: int
+            The number of columns in the previous layer.
+        code_layer: Keras.Dense
+            The hidden layer immediately preceding this layer. code_layer will pass its activation to this layer.
+        _input: Keras.Input
+            The input layer created by `Autoencoder.start_encoder`
+
+        Returns
+        -------
+        None
+
+        """
         try:
             self.input = _input
             self.nbr_columns = nbr_columns
-            nbr_drop_columns = int(nbr_columns * self.dropout_rate)
 
             if self.compression_factor == 0:
                 # Behavior undefined. Do not change feature space.
                 self.compression_factor = 1
 
+            # encoding_dim is the number of columns in this layer
             encoding_dim = ceil(nbr_columns / self.compression_factor)
             self.encoding_dim = encoding_dim
+
             code_layer = Dense(encoding_dim, activation=self.encoder_activation,
                                activity_regularizer=self.activity_regularizer)(code_layer)
             self.code_layer = code_layer
@@ -160,55 +195,23 @@ class Autoencoder(object):
         except Exception as e:
             print(e)
 
-
-    def train(self, train_df, validate_df):
+    def __dropout__(self, input_df, nbr_drop_columns):
         """
-        Establishes a reconstruction model and encoder, and trains these on the input.
-        Validation set is drawn from the input.
+        Zeroes out n columns per example in input_df, where n is the number specified by nbr_columns.
+        The columns to be zeroed out are chosen independently at random.
 
         Parameters
         ----------
-        :train_df:    pandas DataFrame, training set.
-        :validate_df: pandas DataFrame, validation set.   
+        input_df: pandas.DataFrame
+            The input dataset
+        nbr_drop_columns: int
+            Number of columns per example to zero out
 
         Returns
-        ----------
+        -------
         None
 
         """
-        try:
-            nbr_columns = train_df.shape[1]
-            self.nbr_columns = nbr_columns
-            nbr_drop_columns = int(nbr_columns*self.dropout_rate)
-
-            if nbr_drop_columns > 0:
-                self.__dropout__(train_df, nbr_drop_columns)
-            if self.compression_factor == 0:
-                # Behavior undefined. Do not change feature space.
-                self.compression_factor = 1
-
-            encoding_dim = ceil(nbr_columns / self.compression_factor)
-
-            input = Input(shape=(nbr_columns,))
-            code_layer = Dense(encoding_dim, activation=self.encoder_activation,
-                               activity_regularizer=self.activity_regularizer)(input)
-            reconstruction_layer = Dense(nbr_columns, activation=self.decoder_activation)(code_layer)
-
-            model = Model(input=input, output=reconstruction_layer)
-            self.model = model
-
-            encoder = Model(input=input, output=code_layer)
-            self.encoder = encoder
-
-            model.compile(optimizer=self.optimizer, loss='binary_crossentropy')
-
-            model.fit(train_df.values, train_df.values, nb_epoch=self.nb_epoch, batch_size=256, verbose=1,
-                            shuffle=True, validation_data=(validate_df.values, validate_df.values))
-
-        except Exception as e:
-            print(e)
-
-    def __dropout__(self, input_df, nbr_drop_columns):
         columns = [j for j in input_df.columns]
         for i in input_df.index:
             np.random.shuffle(columns)
@@ -220,7 +223,6 @@ class TPOT(object):
     """TPOT automatically creates and optimizes machine learning pipelines using genetic programming."""
 
     update_checked = False
-    encoder_stack = []
 
     def __init__(self, population_size=100, generations=100,
                  mutation_rate=0.9, crossover_rate=0.05,
@@ -335,6 +337,9 @@ class TPOT(object):
 
         for val in np.linspace(0.1, 10, 100):
             self._pset.addTerminal(val, Compression_Factor)
+            if val <= 1:
+                for i in range(10):
+                    self._pset.addTerminal(val, Compression_Factor)
 
         self._pset.addTerminal(True, Bool)
         self._pset.addTerminal(False, Bool)
@@ -364,7 +369,7 @@ class TPOT(object):
             self._pset.addTerminal(val, Activity_Regularization_Parameter)
             #self._pset.addTerminal(val, Dropout_Rate)
 
-        # Dummies for DEAP mutation, never produce a better pipeline
+        # Dummies for DEAP mutation, never produce a better pipeline, necessary to avoid execution halting exception
         self._pset.addTerminal([0,0], Classified_DF )
         self._pset.addTerminal([0,0], Scaled_DF)
 
@@ -389,6 +394,21 @@ class TPOT(object):
             self.scoring_function = scoring_function
 
     def set_training_classes_vectorized(self, classes_vec):
+        """
+        Call this method before fitting TPOT.
+        DELFT needs both forms of the class: vector form and scalar form.
+        This method allows the user to set the vector form of the labels in the training dataset.
+
+        Parameters
+        ----------
+        classes_vec: numpy.array
+            an n-by-m matrix of n examples and m classes
+            Every column contains zeroes (0), except for one column, which contains a 1.
+
+        Returns
+        -------
+        None
+        """
         self._training_classes_vec = classes_vec
 
     def fit(self, features, classes):
@@ -412,10 +432,11 @@ class TPOT(object):
 
         """
         try:
-
-            # Store the training features and classes for later use
+            # Fitting and not scoring flag.
             self._training_testing_data = False
             # self._training_classes_vec = (np.arange(max(classes) + 1) == classes[:, None]).astype(np.float32)
+
+            # Store the training features and classes for later use
             self._training_features = features
             self._training_classes = classes
 
@@ -573,7 +594,6 @@ class TPOT(object):
         return self.predict(features)
 
     def score(self, testing_features, testing_classes):
-        # type: (object, object) -> object
         """Estimates the testing accuracy of the optimized pipeline.
 
         Parameters
@@ -668,7 +688,40 @@ class TPOT(object):
     def _autoencoder(self, input_df, compression_factor, encoder_acivation,
                      decoder_activation, optimizer, activity_regularizer,
                      activity_regularizer_param1, activity_regularizer_param2):
+        """
+        First layer of an artificial neural network
 
+        Parameters
+        ----------
+        input_df: pandas.DataFrame {n_samples, n_features+['class', 'group', 'guess']}
+            Input dataframe.
+        compression_factor: Compression_Factor, range (0, 10]
+            Determines the number of neurons in the first hidden layer.
+        encoder_activation: Activation
+            The activation function of this layer
+        decoder_activation: Activation
+            The activation function of the decoding layer that corresponds to this encoding layer in a
+            stacked autoencoder architecture. Used in pre-training a neural network.
+        optimizer: Optimizer
+            The optimization method to control the gradient steps of the algorithm.
+            Only the optimizer in the first layer is used.
+        activity_regularizer: Activity_Regularizer
+            The activity regularizer to help the algorithm find simpler models and generalize better.
+        activity_regularizer_param1: Activity_Regularization_Parameter
+            First activity regularization parameter
+        activity_regularizer_param2: Activity_Regularization_Parameter
+            Second activity regularization parameter. Only used when using l1l2 activity regularization.
+
+        Returns
+        -------
+        (encoding_dim, code_layer, input), where
+        encoding_dim: int
+            Number of neurons in the first layer.
+        code_layer: Keras.Dense
+            The first hidden layer.
+        input: Keras.Input
+            The input layer.
+        """
         # reset the encoder stack
         # used to build and fit stacked autoencoders with arbitrary number of layers
         self.encoder_stack = []
@@ -697,6 +750,41 @@ class TPOT(object):
     def _hidden_autoencoder(self, input_tuple, compression_factor, encoder_acivation,
                      decoder_activation, optimizer, activity_regularizer,
                      activity_regularizer_param1, activity_regularizer_param2):
+        """
+        Any hidden layer, except the first hidden layer, of an artificial neural network.
+
+        Parameters
+        ----------
+        input_tuple: (int, Keras.Dense, Keras.Input)
+            The output from either the preceding self._autoencoder or the preceding self._hidden_autoencoder
+            This information is needed to connect the next hidden layer.
+        compression_factor: Compression_Factor, range (0, 10]
+            Determines the number of neurons in this hidden layer.
+        encoder_activation: Activation
+            The activation function of this layer
+        decoder_activation: Activation
+            The activation function of the decoding layer that corresponds to this encoding layer in a
+            stacked autoencoder architecture. Used in pre-training a neural network.
+        optimizer: Optimizer
+            The optimization method to control the gradient steps of the algorithm.
+            Only the optimizer in the first layer is used.
+        activity_regularizer: Activity_Regularizer
+            The activity regularizer to help the algorithm find simpler models and generalize better.
+        activity_regularizer_param1: Activity_Regularization_Parameter
+            First activity regularization parameter
+        activity_regularizer_param2: Activity_Regularization_Parameter
+            Second activity regularization parameter. Only used when using l1l2 activity regularization.
+
+        Returns
+        -------
+        (encoding_dim, code_layer, input), where
+        encoding_dim: int
+            Number of neurons in this layer.
+        code_layer: Keras.Dense
+            This hidden layer.
+        input: Keras.Input
+            The input layer (from the first layer).
+        """
 
         if type(input_tuple) == type(pd.DataFrame):
             # Just as a precaution. In case an evolved pipeline attaches _hidden_autoencoder
@@ -723,9 +811,24 @@ class TPOT(object):
         autoencoder.stack_encoder(*input_tuple)
 
         self.encoder_stack.append(autoencoder)
-        return input_tuple
+        return autoencoder.encoding_dim, autoencoder.code_layer, autoencoder.input
 
     def _compile_autoencoder(self, input_df):
+        """
+        Pre-trains the stacked autoencoder, and then connects the first half of the stacked autoencoder
+        to a classification layer to convert it into an artificial neural network. This method is necessary
+        because it pops encoders from a LIFO stack to build their corresponding decoders.
+
+        Parameters
+        ----------
+        input_df: DUMMY
+            used for strong typing in DEAP.
+
+        Returns
+        -------
+        input_df: pandas.DataFrame {n_samples, n_features + ['guess', 'group', 'class']}
+            Returns a DataFrame containing the classification guesses for each example.
+        """
 
         if self._training_testing_data:
             # This runs when we are scoring the test set.
@@ -739,7 +842,6 @@ class TPOT(object):
         self.encoder_stack.reverse()
         encoded_layer = self.encoder_stack[0].code_layer
 
-
         train_data = train_df.drop(self.non_feature_columns, axis=1).astype(np.float64)
         validate_data = validate_df.drop(self.non_feature_columns, axis=1).astype(np.float64)
 
@@ -747,6 +849,7 @@ class TPOT(object):
         _input = None
         target_layer = None
         hashable = []
+
         for autoencoder in self.encoder_stack:
             _input = autoencoder.input
             if decoder is None:
@@ -757,24 +860,30 @@ class TPOT(object):
             hashable.append(autoencoder.decoder_activation)
 
 
-
+        # Stacked Autoencoder, reconstructor
         model = Model(input=_input, output=decoder)
+
+        # Stacked Autoencoder, encoder
         encoder = Model(input=_input, output=encoded_layer)
+
+        # Artificial Neural Network, classifier
         classifier = Model(input=_input, output=target_layer)
 
-        # Unsupervised pretraining
+        # Unsupervised pre-training
         model.compile(optimizer=optimizer, loss='binary_crossentropy')
 
-        model.fit(train_data.values, train_data.values, nb_epoch=nb_epoch*2, batch_size=512, verbose=1,
+        model.fit(train_data.values, train_data.values, nb_epoch=nb_epoch, batch_size=256, verbose=1,
                   shuffle=True, validation_data=(validate_data.values, validate_data.values))
 
         # Supervised training
         classifier.compile(optimizer=optimizer, loss='binary_crossentropy')
-        classifier.fit(train_data.values, np.array(self._training_classes_vec_train), nb_epoch=nb_epoch*5, batch_size=512,
+        classifier.fit(train_data.values, np.array(self._training_classes_vec_train), nb_epoch=nb_epoch*5, batch_size=256,
                        verbose=1, shuffle=True)
 
+        # Restore the training dataset into input_df
         input_df = train_df.append(validate_df)
         input_df = input_df.reset_index(drop=True)
+
         # If there are no features left (i.e., only 'class', 'group', and 'guess' remain in the DF), then there is nothing to do
         if len(input_df.columns) == 3:
             return input_df

--- a/delft/delft.py
+++ b/delft/delft.py
@@ -349,7 +349,7 @@ class TPOT(object):
         for val in np.linspace(0.1, 10, 100):
             self._pset.addTerminal(val, Compression_Factor)
             if val <= 1:
-                for i in range(10):
+                for i in range(20):
                     self._pset.addTerminal(val, Compression_Factor)
 
         self._pset.addTerminal(True, Bool)
@@ -383,10 +383,10 @@ class TPOT(object):
         for val in np.concatenate(([1e-6, 1e-5, 1e-4, 1e-3, 1e-2, 1e-1], np.linspace(0., 1., 101))):
             self._pset.addTerminal(val, Activity_Regularization_Parameter)
 
-        for val in np.linspace(0., 1., 101):
+        for val in np.linspace(0., .65, 101):
             self._pset.addTerminal(val, Dropout_Rate)
 
-        for i in range(75):
+        for i in range(15):
             self._pset.addTerminal(0.0, Dropout_Rate)
 
         # Dummies for DEAP mutation, never produce a better pipeline, necessary to avoid execution halting exception

--- a/delft/driver.py
+++ b/delft/driver.py
@@ -128,12 +128,73 @@ def load_notMNIST_Vector():
 
 
 def load_MNIST():
-    global X_train, X_test, y_train, y_test
-    digits = load_digits()
-    X_train, X_test, y_train, y_test = train_test_split(digits.data, digits.target, train_size=0.75, test_size=0.25)
+    global X_train, X_test, y_train, y_test, y_train_vec
+    # digits = load_digits()
+    # X_train, X_test, y_train, y_test = train_test_split(digits.data, digits.target, train_size=0.75, test_size=0.25)
+    train_data_filename = "../data/mnist.train"
+    test_data_filename = "../data/mnist.test"
+
+    train_dataset = np.loadtxt(train_data_filename, np.int32)
+    y_train = train_dataset[:, 0]
+    nbr_classes = max(y_train) + 1
+    y_train_vec = (np.arange(nbr_classes) == y_train[:, None]).astype(np.float32)
+    X_train = train_dataset[:, 1:]
+
+    test_dataset = np.loadtxt(test_data_filename, np.int32)
+    y_test = test_dataset[:, 0]
+    X_test = test_dataset[:, 1:]
+
+def load_CIFAR10():
+    global X_train, X_test, y_train, y_test, y_train_vec
+    train_data_filename = "../data/cifar-10-training.csv"
+    test_data_filename = "../data/cifar-10-testing.csv"
+
+
+    train_dataset = np.loadtxt(train_data_filename, np.int32, delimiter=',')
+    y_train = train_dataset[:, 0]
+    nbr_classes = max(y_train) + 1
+    y_train_vec = (np.arange(nbr_classes) == y_train[:, None]).astype(np.float32)
+    X_train = train_dataset[:, 1:]
+
+    test_dataset = np.loadtxt(test_data_filename, np.int32, delimiter=',')
+    y_test = test_dataset[:, 0]
+    X_test = test_dataset[:, 1:]
+
+def load_CIFAR100_Coarse():
+    global X_train, X_test, y_train, y_test, y_train_vec
+    data_filename = "../data/cifar-100-coarse.csv"
+
+    dataset = np.loadtxt(data_filename, np.int32, delimiter=',')
+
+    test_dataset = dataset[1:10001]
+    train_dataset = dataset[10001:]
+
+    y_train = train_dataset[:, 0]
+    nbr_classes = max(y_train) + 1
+    y_train_vec = (np.arange(nbr_classes) == y_train[:, None]).astype(np.float32)
+    X_train = train_dataset[:, 1:]
+    y_test = test_dataset[:, 0]
+    X_test = test_dataset[:, 1:]
+
+def load_CIFAR100_Fine():
+    global X_train, X_test, y_train, y_test, y_train_vec
+    data_filename = "../data/cifar-100-fine.csv"
+
+    dataset = np.loadtxt(data_filename, np.int32, delimiter=',')
+
+    test_dataset = dataset[1:10001]
+    train_dataset = dataset[10001:]
+
+    y_train = train_dataset[:, 0]
+    nbr_classes = max(y_train) + 1
+    y_train_vec = (np.arange(nbr_classes) == y_train[:, None]).astype(np.float32)
+    X_train = train_dataset[:, 1:]
+    y_test = test_dataset[:, 0]
+    X_test = test_dataset[:, 1:]
+
 
 def load_ChaLearn(prefix):
-    global X_train, X_test, y_train, y_test
+    global X_train, X_test, y_train, y_test, y_train_vec
     imputer = Imputer(strategy="median")
     data_filename = prefix + ".data"
     solution_filename = prefix + ".solution"
@@ -146,6 +207,7 @@ def load_ChaLearn(prefix):
     X_train, y_train = subsample(X_train, y_train, rate=0.1)
     try:
         columns = y_train.shape[1]
+        y_train_vec = y_train
         y_train = np.argmax(y_train, 1)
         y_test = np.argmax(y_test, 1)
     except IndexError:
@@ -176,8 +238,12 @@ def main():
         load_MNIST()
     elif options.dataset == "not_mnist":
         load_notMNIST()
-    elif options.dataset == "not_mnist_vector":
-        load_notMNIST_Vector()
+    elif options.dataset == "cifar10":
+        load_CIFAR10()
+    elif options.dataset == "cifar100coarse":
+        load_CIFAR100_Coarse()
+    elif options.dataset == "cifar100fine":
+        load_CIFAR100_Fine()
     elif options.dataset == "albert":
         load_ALBERT()
     elif options.dataset == "dilbert":

--- a/delft/driver.py
+++ b/delft/driver.py
@@ -267,7 +267,7 @@ def main():
     elif options.dataset == "volkert":
         load_VOLKERT()
 
-    tpot = TPOT(generations=1, population_size=5, verbosity=2, mutation_rate=0.9, crossover_rate=0.05)
+    tpot = TPOT(generations=5, population_size=5, verbosity=2, mutation_rate=0.9, crossover_rate=0.05)
     tpot.set_training_classes_vectorized(y_train_vec)
     tpot.fit(X_train, y_train)
     print(tpot.score(X_test, y_test))

--- a/delft/driver.py
+++ b/delft/driver.py
@@ -12,6 +12,12 @@ from sklearn.preprocessing import Imputer
 
 import sys
 
+X_train = None
+X_test = None
+y_train = None
+y_test = None
+y_train_vec = None
+
 def subsample(X_train, y_train, rate):
     indices = [i for i in range(X_train.shape[0])]
     indices = np.random.permutation(indices)
@@ -137,8 +143,9 @@ def load_MNIST():
     train_dataset = np.loadtxt(train_data_filename, np.int32)
     y_train = train_dataset[:, 0]
     nbr_classes = max(y_train) + 1
-    y_train_vec = (np.arange(nbr_classes) == y_train[:, None]).astype(np.float32)
     X_train = train_dataset[:, 1:]
+    X_train, y_train = subsample(X_train, y_train, 0.1)
+    y_train_vec = (np.arange(nbr_classes) == y_train[:, None]).astype(np.float32)
 
     test_dataset = np.loadtxt(test_data_filename, np.int32)
     y_test = test_dataset[:, 0]
@@ -149,12 +156,12 @@ def load_CIFAR10():
     train_data_filename = "../data/cifar-10-training.csv"
     test_data_filename = "../data/cifar-10-testing.csv"
 
-
     train_dataset = np.loadtxt(train_data_filename, np.int32, delimiter=',')
     y_train = train_dataset[:, 0]
     nbr_classes = max(y_train) + 1
-    y_train_vec = (np.arange(nbr_classes) == y_train[:, None]).astype(np.float32)
     X_train = train_dataset[:, 1:]
+    X_train, y_train = subsample(X_train, y_train, 0.1)
+    y_train_vec = (np.arange(nbr_classes) == y_train[:, None]).astype(np.float32)
 
     test_dataset = np.loadtxt(test_data_filename, np.int32, delimiter=',')
     y_test = test_dataset[:, 0]
@@ -164,15 +171,17 @@ def load_CIFAR100_Coarse():
     global X_train, X_test, y_train, y_test, y_train_vec
     data_filename = "../data/cifar-100-coarse.csv"
 
-    dataset = np.loadtxt(data_filename, np.int32, delimiter=',')
+    dataset = np.loadtxt(data_filename, np.int32, delimiter='\t')
 
     test_dataset = dataset[1:10001]
     train_dataset = dataset[10001:]
 
     y_train = train_dataset[:, 0]
     nbr_classes = max(y_train) + 1
-    y_train_vec = (np.arange(nbr_classes) == y_train[:, None]).astype(np.float32)
     X_train = train_dataset[:, 1:]
+    X_train, y_train = subsample(X_train, y_train, 0.1)
+    y_train_vec = (np.arange(nbr_classes) == y_train[:, None]).astype(np.float32)
+
     y_test = test_dataset[:, 0]
     X_test = test_dataset[:, 1:]
 
@@ -180,17 +189,20 @@ def load_CIFAR100_Fine():
     global X_train, X_test, y_train, y_test, y_train_vec
     data_filename = "../data/cifar-100-fine.csv"
 
-    dataset = np.loadtxt(data_filename, np.int32, delimiter=',')
+    dataset = np.loadtxt(data_filename, np.int32, delimiter='\t')
 
     test_dataset = dataset[1:10001]
     train_dataset = dataset[10001:]
 
     y_train = train_dataset[:, 0]
     nbr_classes = max(y_train) + 1
-    y_train_vec = (np.arange(nbr_classes) == y_train[:, None]).astype(np.float32)
     X_train = train_dataset[:, 1:]
+    X_train, y_train = subsample(X_train, y_train, 0.1)
+    y_train_vec = (np.arange(nbr_classes) == y_train[:, None]).astype(np.float32)
+
     y_test = test_dataset[:, 0]
     X_test = test_dataset[:, 1:]
+
 
 
 def load_ChaLearn(prefix):
@@ -255,7 +267,7 @@ def main():
     elif options.dataset == "volkert":
         load_VOLKERT()
 
-    tpot = TPOT(generations=5, population_size=5, verbosity=2, mutation_rate=0.9, crossover_rate=0.05)
+    tpot = TPOT(generations=1, population_size=5, verbosity=2, mutation_rate=0.9, crossover_rate=0.05)
     tpot.set_training_classes_vectorized(y_train_vec)
     tpot.fit(X_train, y_train)
     print(tpot.score(X_test, y_test))


### PR DESCRIPTION
### Dropout

Implemented dropout for denoising autoencoders. Following literature recommendations, it is now more likely that DELFT will *expand* the dimensions of a hidden layer in this version than it was before. This is because compressing and destroying input results in too much loss of information. DELFT is still able to evolve compressed representations without dropout, if this configuration is conducive to better classification accuracy.

Caveat: because DELFT can search a larger set of configurations, it can find better pipelines than it could before, but it also has to find good configurations hidden in a large problem space. This means DELFT should be run for more generations, or with a larger population. Another consideration is that since the hidden layers can expand the dimensions of the previous layer (rather than just compress it) to denoise the input, the tuning and evaluation of each pipeline takes more time. 

### Imputer

The imputer is now a pipeline operator, and its strategy is evolved by DELFT. Thus, DELFT now supports datasets with missing values, without the need of imputation by the end-user.